### PR TITLE
Fix median

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -471,8 +471,11 @@ The values are refreshed every 5 minutes in order to fit with the measurement fr
 };
 
 function data_median(data) {
-	var d_temp = data.filter(d => !d.o.indoor);
-	return median(d_temp, (o) => o.o.data[user_selected_value]);
+	var d_temp = data
+		.filter(d => !d.o.indoor)
+		.map(o => o.o.data[user_selected_value])
+		.sort();
+	return median(d_temp);
 }
 
 function switchLegend(val) {


### PR DESCRIPTION
The median function of D3 requires the array to be sorted. The [documentation](https://github.com/d3/d3-array/blob/master/README.md#median) is not explicit about it (but mentions it for the similar quantile function).

I have attached a screenshot of the bug manifesting with one outlier.

![luftdaten4](https://user-images.githubusercontent.com/2863907/60624637-19a82680-9de6-11e9-9508-1cdebca2cfbd.png)

As it is hard to force this bug to appear in the life map, I've also attached a few test cases (run with `jest`) as well.

```javascript
const { median } = require('../node_modules/d3-array/dist/d3-array');

it('Tests d3 median', () => {
    expect(median([3, 2, 160, 5, 0])).toBe(160);
    expect(median([0, 2, 3, 5, 160])).toBe(3);
    expect(median([3, 2, 160, 5, 0].sort())).toBe(3);
});

it('Tests with complex object', () => {
    const user_selected_value = 'PM10';
    const d_temp = [3, 2, 160, 5, 0].map((v) => ({ o: { data: { PM10: v } } }));

    const result = median(d_temp, (o) => o.o.data[user_selected_value]);
    expect(result).toBe(160);

    const mappedData = d_temp.map(o => o.o.data[user_selected_value]).sort();
    const resultSorted = median(mappedData);
    expect(resultSorted).toBe(3);
});
```